### PR TITLE
Enable the compare script to work on GHA

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           path: 'head'
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
           cache: 'pip'
@@ -68,7 +68,7 @@ jobs:
       - name: "Setup Ubuntu"
         run: |
           # Run the setup script from HEAD so changes from PRs are reflected.
-          ./head/scripts/setup-ubuntu.sh
+          sudo ./head/scripts/setup-ubuntu.sh
 
       - name: build-benchmarks
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,6 +60,11 @@ jobs:
         with:
           path: 'head'
           submodules: 'recursive'
+      
+      - run: |
+          apt update
+          apt install -y lsb-release
+          
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # container: ghcr.io/facebookincubator/velox-dev:circleci-avx
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -42,7 +42,8 @@ jobs:
             mkdir -p /tmp/test_xml_output/
             echo "XML_OUTPUT_FILE=/tmp/test_xml_output/" >> $GITHUB_ENV
 
-            # Set up ccache configs.
+            # TODO CCACHE caching
+            # Set up ccache configs .
             # mkdir -p .ccache
             # echo "export CCACHE_DIR=$(realpath .ccache)" >> $BASH_ENV
             # ccache -sz -M 5Gi
@@ -77,14 +78,14 @@ jobs:
       - name: build-benchmarks
         run: |
           build_benchmarks() {
-            echo "::start-group::Build $2 Benchmarks"
+            echo "::group::Build $2 Benchmarks"
             pushd $1
             n_cores=$(nproc)
             make benchmarks-basic-build NUM_THREADS=$n_cores MAX_HIGH_MEM_JOBS=$((n_cores/2)) MAX_LINK_JOBS=$n_cores
             ccache -s
             mkdir -p $3
             cp -r --verbose _build/release/velox/benchmarks/basic/* $3
-            echo "::end-group::"
+            echo "::endgroup::"
             popd
           }
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,8 +25,8 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-20.04
-    # container: ghcr.io/facebookincubator/velox-dev:circleci-avx
+    runs-on: ubuntu-latest
+    container: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       BINARY_DIR: "${{ github.workspace }}/benchmarks/"
@@ -66,14 +66,14 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'head/scripts/*'
       
-      - name: "Setup Ubuntu"
-        run: |
-          # install libunwind explicitly to avoid dependecy hell
-          # https://bugs.launchpad.net/ubuntu/+source/google-glog/+bug/1991919
-          sudo apt install -y libunwind-dev
+      # - name: "Setup Ubuntu"
+      #   run: |
+      #     # install libunwind explicitly to avoid dependecy hell
+      #     # https://bugs.launchpad.net/ubuntu/+source/google-glog/+bug/1991919
+      #     sudo apt install -y libunwind-dev
 
-          # Run the setup script from HEAD so changes from PRs are reflected.
-          sudo ./head/scripts/setup-ubuntu.sh
+      #     # Run the setup script from HEAD so changes from PRs are reflected.
+      #     sudo ./head/scripts/setup-ubuntu.sh
 
       - name: build-benchmarks
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
-          cache-dependency-path: 'head/scripts/requirements.txt'
+          cache-dependency-path: './head/scripts/requirements.txt'
       
       - name: "Setup Ubuntu"
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "facebookincubator/velox"
+          ref: "e1fe3ce469d47a2ad1355afa952646b1f098e3a3"
           path: 'base'
           submodules: 'recursive'
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,11 +65,11 @@ jobs:
           apt update
           apt install -y lsb-release python3
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
-          cache: 'pip'
-          cache-dependency-path: 'head/scripts/*'
+      # - uses: actions/setup-python@v4
+      #   with:
+      #     python-version: '3.8'
+      #     cache: 'pip'
+      #     cache-dependency-path: 'head/scripts/*'
       
       # - name: "Setup Ubuntu"
       #   run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
-          cache-dependency-path: './head/scripts/requirements.txt'
+          cache-dependency-path: 'head/scripts/*'
       
       - name: "Setup Ubuntu"
         run: |
@@ -102,7 +102,7 @@ jobs:
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}"
             make benchmarks-basic-run \
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}"
-                # --conbench_upload_run_id CircleCI-${CIRCLE_BUILD_NUM}-dedicated"
+                # --conbench_upload_run_id GitHub-${{ github.run_id }}-dedicated"
             ./scripts/benchmark-runner.py compare \
                 --baseline_path ${BASELINE_OUTPUT_PATH} \
                 --target_path ${TARGET_OUTPUT_PATH} \
@@ -122,7 +122,7 @@ jobs:
       #         make benchmarks-basic-run \
       #             EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/baseline/ --output_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
       #         make benchmarks-basic-run \
-      #             EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/target/ --output_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN} --conbench_upload_run_id CircleCI-${CIRCLE_BUILD_NUM}-dedicated"
+      #             EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/target/ --output_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN} --conbench_upload_run_id GitHub-${{ github.run_id }}-dedicated"
       #         ./scripts/benchmark-runner.py compare \
       #             --baseline_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ \
       #             --target_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           path: 'head'
           submodules: 'recursive'
-      
+
       - run: |
           apt update
           apt install -y lsb-release python3 pip
@@ -73,7 +73,7 @@ jobs:
       #     python-version: '3.8'
       #     cache: 'pip'
       #     cache-dependency-path: 'head/scripts/*'
-      
+
       # - name: "Setup Ubuntu"
       #   run: |
       #     # install libunwind explicitly to avoid dependecy hell
@@ -108,9 +108,6 @@ jobs:
       - name: "Run Benchmarks - Full Round"
         working-directory: 'head'
         run: |
-            # TODO: For now we just compare the target binary with itself, until we
-            # stabilize benchmark runs. We should eventually have two different
-            # set of binaries.
             make benchmarks-basic-run \
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}"
             make benchmarks-basic-run \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,147 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Linux Benchmark
+
+on:
+  pull_request:
+  # only running on changes to source files would be possible
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    # container: ghcr.io/facebookincubator/velox-dev:circleci-avx
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      BINARY_DIR: "${{ github.workspace }}/benchmarks/"
+      CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
+      CONBENCH_HOST: "GitHub-runner"
+      LINUX_DISTRO: "ubuntu"
+      RESULTS_ROOT: "${{ github.workspace }}/benchmark-results"
+      BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"
+      TARGET_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/target/"
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+
+      - run: |
+            # Set up xml gtest output.
+            mkdir -p /tmp/test_xml_output/
+            echo "XML_OUTPUT_FILE=/tmp/test_xml_output/" >> $GITHUB_ENV
+
+            # Set up ccache configs.
+            # mkdir -p .ccache
+            # echo "export CCACHE_DIR=$(realpath .ccache)" >> $BASH_ENV
+            # ccache -sz -M 5Gi
+
+      - name: "Checkout Base"
+        uses: actions/checkout@v3
+        with:
+          repository: "facebookincubator/velox"
+          path: 'base'
+          submodules: 'recursive'
+
+      - name: "Checkout Head"
+        uses: actions/checkout@v3
+        with:
+          path: 'head'
+          submodules: 'recursive'
+      
+      - name: "Setup Ubuntu"
+        run: |
+          # Run the setup script from HEAD so changes from PRs are reflected.
+          ./head/scripts/setup-ubuntu.sh
+
+      - name: build-benchmarks
+        run: |
+          build_benchmarks() {
+            echo "::start-group::Build $2 Benchmarks"
+            pushd $1
+            n_cores=$(nproc)
+            make benchmarks-basic-build NUM_THREADS=$n_cores MAX_HIGH_MEM_JOBS=$((n_cores/2)) MAX_LINK_JOBS=$n_cores
+            ccache -s
+            mkdir -p $3
+            cp -r --verbose _build/release/velox/benchmarks/basic/* $3
+            echo "::end-group::"
+            popd
+          }
+
+          build_benchmarks base Baseline ${BINARY_DIR}/baseline/
+          build_benchmarks head Target ${BINARY_DIR}/target/
+
+      - name: "Install benchmark dependencies"
+        run: |
+          cd head
+          python -m pip install -r scripts/benchmark-requirements.txt
+
+      - name: "Run Benchmarks - Full Round"
+        working-directory: 'head'
+        run: |
+            # TODO: For now we just compare the target binary with itself, until we
+            # stabilize benchmark runs. We should eventually have two different
+            # set of binaries.
+            make benchmarks-basic-run \
+                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}"
+            make benchmarks-basic-run \
+                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}"
+                # --conbench_upload_run_id CircleCI-${CIRCLE_BUILD_NUM}-dedicated"
+            ./scripts/benchmark-runner.py compare \
+                --baseline_path ${BASELINE_OUTPUT_PATH} \
+                --target_path ${TARGET_OUTPUT_PATH} \
+                --rerun_json_output "${RESULTS_ROOT}/rerun_json_output_0.json" \
+                --do_not_fail
+      # - name: "Run Benchmarks - Reruns"
+      #   working-directory: 'head'
+      #   run: |
+      #       for i in 1 2 3 4 5; do
+      #         CURRENT_JSON_RERUN="${RESULTS_ROOT}/rerun_json_output_$((${i} - 1)).json"
+      #         NEXT_JSON_RERUN="${RESULTS_ROOT}/rerun_json_output_${i}.json"
+      #         if [ ! -s "${CURRENT_JSON_RERUN}" ]; then
+      #           echo "--> Rerun iteration ${i} found empty file. Finalizing."
+      #           break
+      #         fi
+      #         echo "--> Starting rerun iteration: ${i}"
+      #         make benchmarks-basic-run \
+      #             EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/baseline/ --output_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
+      #         make benchmarks-basic-run \
+      #             EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/target/ --output_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN} --conbench_upload_run_id CircleCI-${CIRCLE_BUILD_NUM}-dedicated"
+      #         ./scripts/benchmark-runner.py compare \
+      #             --baseline_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ \
+      #             --target_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ \
+      #             --rerun_json_output ${NEXT_JSON_RERUN} \
+      #             --do_not_fail
+      #       done
+      - name: "Run Benchmarks - Summary"
+        working-directory: 'head'
+        run: |
+            ./scripts/benchmark-runner.py compare \
+                --baseline_path ${BASELINE_OUTPUT_PATH} \
+                --target_path ${TARGET_OUTPUT_PATH} \
+                --recursive \
+                --do_not_fail
+      - uses: actions/upload-artifact@v3
+        with:
+          path: "benchmark-results"
+          name: "benchmark-results"
+      - uses: actions/upload-artifact@v3
+        with:
+          path: "/tmp/test_xml_output/"
+          name: "test-results"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "facebookincubator/velox"
-          ref: "5670a7b9f4f801e3e4cd72fc87fe9ee34d211a61"
           path: 'base'
           submodules: 'recursive'
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "facebookincubator/velox"
+          ref: "5670a7b9f4f801e3e4cd72fc87fe9ee34d211a61"
           path: 'base'
           submodules: 'recursive'
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
@@ -82,7 +86,6 @@ jobs:
 
       - name: build-benchmarks
         run: |
-          ls -la
           build_benchmarks() {
             echo "::group::Build $2 Benchmarks"
             pushd $1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -130,9 +130,9 @@ jobs:
               fi
               echo "--> Starting rerun iteration: ${i}"
               make benchmarks-basic-run \
-                  EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/baseline/ --output_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
+                  EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
               make benchmarks-basic-run \
-                  EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/target/ --output_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
+                  EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
               ./scripts/benchmark-runner.py compare \
                   --baseline_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ \
                   --target_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,6 +67,10 @@ jobs:
       
       - name: "Setup Ubuntu"
         run: |
+          # install libunwind explicitly to avoid dependecy hell
+          # https://bugs.launchpad.net/ubuntu/+source/google-glog/+bug/1991919
+          sudo apt install -y libunwind-dev
+
           # Run the setup script from HEAD so changes from PRs are reflected.
           sudo ./head/scripts/setup-ubuntu.sh
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: build-benchmarks
         run: |
+          ls -la
           build_benchmarks() {
             echo "::group::Build $2 Benchmarks"
             pushd $1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ defaults:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
@@ -46,11 +46,9 @@ jobs:
             mkdir -p /tmp/test_xml_output/
             echo "XML_OUTPUT_FILE=/tmp/test_xml_output/" >> $GITHUB_ENV
 
-            # TODO CCACHE caching
             # Set up ccache configs .
-            # mkdir -p .ccache
-            # echo "export CCACHE_DIR=$(realpath .ccache)" >> $BASH_ENV
-            # ccache -sz -M 5Gi
+            mkdir -p .ccache
+            ccache -sz -M 5Gi
 
       - name: "Checkout Base"
         uses: actions/checkout@v3
@@ -68,7 +66,7 @@ jobs:
       
       - run: |
           apt update
-          apt install -y lsb-release python3
+          apt install -y lsb-release python3 pip
 
       # - uses: actions/setup-python@v4
       #   with:
@@ -105,7 +103,7 @@ jobs:
       - name: "Install benchmark dependencies"
         run: |
           cd head
-          python -m pip install -r scripts/benchmark-requirements.txt
+          python3 -m pip install -r scripts/benchmark-requirements.txt
 
       - name: "Run Benchmarks - Full Round"
         working-directory: 'head'
@@ -117,33 +115,33 @@ jobs:
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}"
             make benchmarks-basic-run \
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}"
-                # --conbench_upload_run_id GitHub-${{ github.run_id }}-dedicated"
+
             ./scripts/benchmark-runner.py compare \
                 --baseline_path ${BASELINE_OUTPUT_PATH} \
                 --target_path ${TARGET_OUTPUT_PATH} \
                 --rerun_json_output "${RESULTS_ROOT}/rerun_json_output_0.json" \
                 --do_not_fail
-      # - name: "Run Benchmarks - Reruns"
-      #   working-directory: 'head'
-      #   run: |
-      #       for i in 1 2 3 4 5; do
-      #         CURRENT_JSON_RERUN="${RESULTS_ROOT}/rerun_json_output_$((${i} - 1)).json"
-      #         NEXT_JSON_RERUN="${RESULTS_ROOT}/rerun_json_output_${i}.json"
-      #         if [ ! -s "${CURRENT_JSON_RERUN}" ]; then
-      #           echo "--> Rerun iteration ${i} found empty file. Finalizing."
-      #           break
-      #         fi
-      #         echo "--> Starting rerun iteration: ${i}"
-      #         make benchmarks-basic-run \
-      #             EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/baseline/ --output_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
-      #         make benchmarks-basic-run \
-      #             EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/target/ --output_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN} --conbench_upload_run_id GitHub-${{ github.run_id }}-dedicated"
-      #         ./scripts/benchmark-runner.py compare \
-      #             --baseline_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ \
-      #             --target_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ \
-      #             --rerun_json_output ${NEXT_JSON_RERUN} \
-      #             --do_not_fail
-      #       done
+      - name: "Run Benchmarks - Reruns"
+        working-directory: 'head'
+        run: |
+            for i in 1 2 3 4 5; do
+              CURRENT_JSON_RERUN="${RESULTS_ROOT}/rerun_json_output_$((${i} - 1)).json"
+              NEXT_JSON_RERUN="${RESULTS_ROOT}/rerun_json_output_${i}.json"
+              if [ ! -s "${CURRENT_JSON_RERUN}" ]; then
+                echo "--> Rerun iteration ${i} found empty file. Finalizing."
+                break
+              fi
+              echo "--> Starting rerun iteration: ${i}"
+              make benchmarks-basic-run \
+                  EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/baseline/ --output_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
+              make benchmarks-basic-run \
+                  EXTRA_BENCHMARK_FLAGS="--binary_path _build/benchmarks/target/ --output_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ --rerun_json_input ${CURRENT_JSON_RERUN}"
+              ./scripts/benchmark-runner.py compare \
+                  --baseline_path ${BASELINE_OUTPUT_PATH}/rerun-${i}/ \
+                  --target_path ${TARGET_OUTPUT_PATH}/rerun-${i}/ \
+                  --rerun_json_output ${NEXT_JSON_RERUN} \
+                  --do_not_fail
+            done
       - name: "Run Benchmarks - Summary"
         working-directory: 'head'
         run: |
@@ -153,6 +151,7 @@ jobs:
                 --recursive \
                 --do_not_fail
       - uses: actions/upload-artifact@v3
+        if: always()
         with:
           path: "benchmark-results"
           name: "benchmark-results"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,8 +63,8 @@ jobs:
       
       - run: |
           apt update
-          apt install -y lsb-release
-          
+          apt install -y lsb-release python3
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,11 +37,6 @@ jobs:
       BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"
       TARGET_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/target/"
     steps:
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-          cache: 'pip'
-
       - run: |
             # Set up xml gtest output.
             mkdir -p /tmp/test_xml_output/
@@ -64,6 +59,11 @@ jobs:
         with:
           path: 'head'
           submodules: 'recursive'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+          cache-dependency-path: 'head/scripts/requirements.txt'
       
       - name: "Setup Ubuntu"
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,7 +437,7 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
 endif()
 find_package(BISON 3.0.4 REQUIRED)
 find_package(FLEX 2.5.13 REQUIRED)
-
+message(STATUS "Found Flex ${FLEX_INCLUDE_DIRS}")
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)
 include_directories(SYSTEM velox/external/duckdb)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,7 +437,7 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
 endif()
 find_package(BISON 3.0.4 REQUIRED)
 find_package(FLEX 2.5.13 REQUIRED)
-message(STATUS "Found Flex ${FLEX_INCLUDE_DIRS}")
+message(STATUS "Found Flex ${FLEX_INCLUDE_DIRS}")`
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)
 include_directories(SYSTEM velox/external/duckdb)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,7 +437,7 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
 endif()
 find_package(BISON 3.0.4 REQUIRED)
 find_package(FLEX 2.5.13 REQUIRED)
-message(STATUS "Found Flex ${FLEX_INCLUDE_DIRS}")`
+
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)
 include_directories(SYSTEM velox/external/duckdb)

--- a/scripts/benchmark-runner.py
+++ b/scripts/benchmark-runner.py
@@ -82,12 +82,13 @@ def compare_file(args, target_data, baseline_data):
         output_map = defaultdict(dict)
         for file_name, data in input_map.items():
             retry = get_retry_name(args, file_name)
-            for row in data:
+            for binary_path, benchmark, time in data:
                 # Folly benchmark exports line separators by mistake as an entry on
                 # the json file.
-                if row[1] == "-":
+                if benchmark == "-":
                     continue
-                output_map[(row[0], row[1])][retry] = row[2]
+                binary_name = pathlib.Path(binary_path).stem
+                output_map[(binary_name, benchmark)][retry] = time
         return output_map
 
     baseline_map = preprocess_data(baseline_data)

--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <string>
 
 #ifdef __BMI2__
 #include <x86intrin.h>


### PR DESCRIPTION
This PR fixes the "Wrong number of retries found" message we were seeing during the compare script.

On CircleCI, we did something like
1. clone HEAD
2. build benchmarks into `/target`
3. check out baseline commit
4. build benchmarks into `/baseline`

So the two sets of benchmark binaries had the same parent path, something like `/home/circleci/project/_build/benchmarks/`.

Now, we're cloning HEAD and the baseline commit into two separate directories, so the parent paths look like
`/__w/velox/velox/head/velox/benchmarks/basic/` and `/__w/velox/velox/base/velox/benchmarks/basic/` respectively. This was basically causing a KeyError in the script when we tried to compare the two.

With this change, we're just using the binary name as the key, instead of the full path to the binary.